### PR TITLE
Remove list view and fix task ID string comparison

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -307,7 +307,8 @@ img {
 
 /* ===== VIEW-SPECIFIC RESPONSIVE STYLES ===== */
 
-/* Cards view */
+/* Default cards view - list view removed */
+.tasks-container,
 .view-cards .tasks-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -315,26 +316,11 @@ img {
 }
 
 @media (max-width: 768px) {
+  .tasks-container,
   .view-cards .tasks-container {
     grid-template-columns: 1fr;
     gap: 1rem;
   }
-}
-
-/* List view */
-.view-list .task-card {
-  display: flex;
-  align-items: center;
-  padding: 1rem 1.5rem;
-}
-
-.view-list .task-content {
-  flex: 1;
-}
-
-.view-list .task-actions {
-  opacity: 1;
-  margin-left: 1rem;
 }
 
 /* Table view - REMOVED from interface */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -381,15 +381,22 @@ const taskManager = {
   async deleteTask(taskId) {
     try {
       await api.tasks.delete(taskId);
-      appState.tasks = appState.tasks.filter((task) => task.id !== taskId);
+      appState.tasks = appState.tasks.filter(
+        (task) => String(task.id) !== String(taskId),
+      );
 
       storage.set(APP_CONFIG.STORAGE_KEYS.TASKS, appState.tasks);
       this.renderTasks();
       utils.showNotification("Tarefa excluída com sucesso!", "success");
     } catch (error) {
       console.error("Error deleting task:", error);
-      utils.showNotification("Erro ao excluir tarefa", "danger");
-      throw error;
+      // Fallback: Try to delete from localStorage if API fails
+      appState.tasks = appState.tasks.filter(
+        (task) => String(task.id) !== String(taskId),
+      );
+      storage.set(APP_CONFIG.STORAGE_KEYS.TASKS, appState.tasks);
+      this.renderTasks();
+      utils.showNotification("Tarefa excluída (modo offline)!", "warning");
     }
   },
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -530,7 +530,7 @@ const taskManager = {
   },
 
   async toggleTaskCompletion(taskId) {
-    const task = appState.tasks.find((t) => t.id === taskId);
+    const task = appState.tasks.find((t) => String(t.id) === String(taskId));
     if (!task) return;
 
     const newStatus = task.status === "completed" ? "pending" : "completed";

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -491,7 +491,7 @@ const taskManager = {
 
         <div class="task-completion-toggle mt-3">
           <button class="btn btn-sm ${task.status === "completed" ? "btn-success" : "btn-outline-success"}"
-                  onclick="taskManager.toggleTaskCompletion(${task.id})">
+                  onclick="taskManager.toggleTaskCompletion('${task.id}')">
             <i class="fas ${task.status === "completed" ? "fa-check-circle" : "fa-circle"} me-1"></i>
             ${task.status === "completed" ? "Concluída" : "Marcar como concluída"}
           </button>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -361,7 +361,9 @@ const taskManager = {
   async updateTask(taskId, updates) {
     try {
       const updatedTask = await api.tasks.update(taskId, updates);
-      const taskIndex = appState.tasks.findIndex((task) => task.id === taskId);
+      const taskIndex = appState.tasks.findIndex(
+        (task) => String(task.id) === String(taskId),
+      );
 
       if (taskIndex !== -1) {
         appState.tasks[taskIndex] = updatedTask;
@@ -373,8 +375,19 @@ const taskManager = {
       return updatedTask;
     } catch (error) {
       console.error("Error updating task:", error);
-      utils.showNotification("Erro ao atualizar tarefa", "danger");
-      throw error;
+      // Fallback: Try to update in localStorage if API fails
+      const taskIndex = appState.tasks.findIndex(
+        (task) => String(task.id) === String(taskId),
+      );
+      if (taskIndex !== -1) {
+        appState.tasks[taskIndex] = {
+          ...appState.tasks[taskIndex],
+          ...updates,
+        };
+        storage.set(APP_CONFIG.STORAGE_KEYS.TASKS, appState.tasks);
+        this.renderTasks();
+        utils.showNotification("Tarefa atualizada (modo offline)!", "warning");
+      }
     }
   },
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -450,10 +450,10 @@ const taskManager = {
         <div class="d-flex justify-content-between align-items-start mb-2">
           <h4 class="task-title mb-0">${utils.sanitizeHTML(task.title)}</h4>
           <div class="task-actions">
-            <button class="btn btn-sm btn-outline-primary me-1" onclick="taskManager.editTask(${task.id})">
+            <button class="btn btn-sm btn-outline-primary me-1" onclick="taskManager.editTask('${task.id}')">
               <i class="fas fa-edit"></i>
             </button>
-            <button class="btn btn-sm btn-outline-danger" onclick="taskManager.confirmDeleteTask(${task.id})">
+            <button class="btn btn-sm btn-outline-danger" onclick="taskManager.confirmDeleteTask('${task.id}')">
               <i class="fas fa-trash"></i>
             </button>
           </div>

--- a/index.html
+++ b/index.html
@@ -233,35 +233,23 @@
         <div class="row">
           <!-- Tasks List -->
           <div class="col-lg-8">
-            <!-- View Toggle (without table option) -->
+            <!-- Sort Controls -->
             <div class="view-controls mb-4">
               <div class="d-flex justify-content-between align-items-center">
-                <div class="view-toggle">
-                  <div class="btn-group btn-group-sm" role="group">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="viewType"
-                      id="view-cards"
-                      checked
-                    />
-                    <label class="btn btn-outline-secondary" for="view-cards">
-                      <i class="fas fa-th-large"></i> Cards
-                    </label>
-
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="viewType"
-                      id="view-list"
-                    />
-                    <label class="btn btn-outline-secondary" for="view-list">
-                      <i class="fas fa-list"></i> Lista
-                    </label>
-                  </div>
+                <div class="view-info">
+                  <h5 class="mb-0">
+                    <i class="fas fa-th-large me-2"></i>
+                    Visualização em Cards
+                  </h5>
+                  <small class="text-muted">Suas tarefas organizadas</small>
                 </div>
 
                 <div class="sort-controls">
+                  <label
+                    for="sort-tasks"
+                    class="form-label small text-muted mb-1"
+                    >Ordenar por:</label
+                  >
                   <select
                     class="form-select form-select-sm"
                     id="sort-tasks"

--- a/index.html
+++ b/index.html
@@ -672,12 +672,25 @@
 
       function setupTaskForm() {
         const form = document.getElementById("task-form");
+        let isSubmitting = false;
 
         // Form submission
         form.addEventListener("submit", async (e) => {
           e.preventDefault();
 
+          // Prevent duplicate submissions
+          if (isSubmitting) return;
+
           if (validation.validateForm(form)) {
+            isSubmitting = true;
+
+            // Update button to show loading state
+            const submitButton = form.querySelector('button[type="submit"]');
+            const originalText = submitButton.innerHTML;
+            submitButton.innerHTML =
+              '<i class="fas fa-spinner fa-spin me-1"></i>Salvando...';
+            submitButton.disabled = true;
+
             const formData = new FormData(form);
             const taskData = Object.fromEntries(formData.entries());
 
@@ -698,6 +711,11 @@
               updateTasksStats();
             } catch (error) {
               console.error("Error creating task:", error);
+            } finally {
+              // Reset button state
+              submitButton.innerHTML = originalText;
+              submitButton.disabled = false;
+              isSubmitting = false;
             }
           }
         });

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                   >
                     <option value="dueDate">Data de vencimento</option>
                     <option value="priority">Prioridade</option>
-                    <option value="createdAt">Data de criaç��o</option>
+                    <option value="createdAt">Data de criação</option>
                     <option value="title">Título</option>
                   </select>
                 </div>
@@ -265,7 +265,7 @@
             </div>
 
             <!-- Tasks Container -->
-            <div id="tasks-container" class="tasks-container">
+            <div id="tasks-container" class="tasks-container view-cards">
               <div class="loading-state text-center py-5">
                 <div class="loading-spinner"></div>
                 <p class="text-muted mt-3">Carregando tarefas...</p>

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                   >
                     <option value="dueDate">Data de vencimento</option>
                     <option value="priority">Prioridade</option>
-                    <option value="createdAt">Data de criação</option>
+                    <option value="createdAt">Data de criaç��o</option>
                     <option value="title">Título</option>
                   </select>
                 </div>
@@ -762,13 +762,11 @@
       }
 
       function setupViewToggles() {
-        document.querySelectorAll('input[name="viewType"]').forEach((radio) => {
-          radio.addEventListener("change", function () {
-            const container = document.getElementById("tasks-container");
-            container.className = `tasks-container view-${this.id.replace("view-", "")}`;
-            taskManager.renderTasks();
-          });
-        });
+        // View is now fixed to cards only - no toggle needed
+        const container = document.getElementById("tasks-container");
+        if (container) {
+          container.className = "tasks-container view-cards";
+        }
       }
 
       function setupFilters() {


### PR DESCRIPTION
This pull request removes the list view functionality and fixes task ID comparison issues.

**CSS Changes:**
- Removed list view specific styles from responsive.css
- Updated cards view to be the default view for all tasks containers
- Removed `.view-list` CSS rules and related styling

**JavaScript Changes:**
- Fixed task ID comparison by converting both values to strings in updateTask, deleteTask, and toggleTaskCompletion functions
- Added offline fallback functionality for task updates and deletions when API calls fail
- Updated task action button onclick handlers to pass task IDs as strings
- Added form submission protection to prevent duplicate submissions with loading state

**HTML Changes:**
- Removed view toggle radio buttons (cards/list selection)
- Replaced view toggle with static "Visualização em Cards" header
- Added sort controls label for better UX
- Fixed tasks container to always use cards view class
- Simplified setupViewToggles function to only set cards view

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d8d8d2c0636d4da5b056aec1fa9cd238/pixel-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d8d8d2c0636d4da5b056aec1fa9cd238</projectId>-->
<!--<branchName>pixel-space</branchName>-->