### PR TITLE
Update form styles and reorder navigation items

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -519,6 +519,101 @@ a:hover {
   }
 }
 
+/* ===== FORM ENHANCEMENTS ===== */
+/* Consistent form field sizing across all devices */
+.form-control,
+.form-select {
+  min-height: 48px;
+  font-size: 1rem;
+  line-height: 1.5;
+  box-sizing: border-box;
+}
+
+.form-select {
+  padding: 0.75rem var(--spacing-md);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--secondary-bg);
+  transition:
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.form-select:focus {
+  border-color: var(--primary-red);
+  box-shadow: 0 0 0 3px rgba(227, 68, 50, 0.1);
+}
+
+/* Textarea consistent styling */
+textarea.form-control {
+  min-height: 100px;
+  resize: vertical;
+}
+
+/* Form validation states */
+.form-control.is-invalid {
+  border-color: var(--priority-high);
+  background-image: none;
+}
+
+.form-control.is-valid {
+  border-color: var(--success-green);
+  background-image: none;
+}
+
+/* Button groups in forms */
+.input-group .btn {
+  min-height: 48px;
+  border: 2px solid var(--border-color);
+  border-left: 0;
+}
+
+.input-group .btn:focus {
+  border-color: var(--primary-red);
+  z-index: 3;
+}
+
+/* Checkbox and radio consistent styling */
+.form-check-input {
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: 0.125rem;
+  border: 2px solid var(--border-color);
+}
+
+.form-check-input:focus {
+  border-color: var(--primary-red);
+  box-shadow: 0 0 0 0.25rem rgba(227, 68, 50, 0.1);
+}
+
+.form-check-input:checked {
+  background-color: var(--primary-red);
+  border-color: var(--primary-red);
+}
+
+/* Switch styling */
+.form-check .form-check-input[type="checkbox"] {
+  border-radius: var(--radius-sm);
+}
+
+/* Form grid improvements */
+.row .form-group {
+  margin-bottom: var(--spacing-lg);
+}
+
+/* Required field indicator */
+.form-label:has(+ .form-control[data-validation*="required"])::after,
+.form-label[for*="email"]::after,
+.form-label[for*="password"]::after,
+.form-label[for*="confirm-password"]::after,
+.form-label[for*="first-name"]::after,
+.form-label[for*="last-name"]::after,
+.form-label[for*="terms"]::after {
+  content: " *";
+  color: var(--priority-high);
+  font-weight: bold;
+}
+
 /* ===== RESPONSIVE DESIGN ===== */
 @media (max-width: 768px) {
   .container-fluid {
@@ -544,6 +639,32 @@ a:hover {
   }
   h3 {
     font-size: 1.25rem;
+  }
+
+  /* Form adjustments for mobile */
+  .form-control,
+  .form-select {
+    min-height: 44px;
+    font-size: 16px; /* Prevents zoom on iOS */
+  }
+
+  .input-group-text {
+    min-height: 44px;
+    padding: 0 0.75rem;
+  }
+
+  .form-error,
+  .form-success {
+    position: static;
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+    white-space: normal;
+    max-width: none;
+  }
+
+  .form-group.has-error,
+  .form-group.has-success {
+    margin-bottom: var(--spacing-lg);
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -40,7 +40,7 @@
 
   /* Typography */
   --font-primary: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-heading: "Graphik", "Inter", sans-serif;
+  --font-heading: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 /* ===== RESET & BASE STYLES ===== */
@@ -363,6 +363,7 @@ a:hover {
 /* ===== FORMS ===== */
 .form-group {
   margin-bottom: var(--spacing-lg);
+  position: relative;
 }
 
 .form-label {
@@ -370,24 +371,57 @@ a:hover {
   margin-bottom: var(--spacing-sm);
   font-weight: 600;
   color: var(--text-primary);
+  font-size: 0.875rem;
 }
 
 .form-control {
   width: 100%;
-  padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--border-color);
+  padding: 0.75rem var(--spacing-md);
+  border: 2px solid var(--border-color);
   border-radius: var(--radius-md);
   font-family: var(--font-primary);
+  font-size: 1rem;
+  min-height: 48px;
   transition:
     border-color 0.3s ease,
     box-shadow 0.3s ease;
   background: var(--secondary-bg);
+  box-sizing: border-box;
 }
 
 .form-control:focus {
   outline: none;
   border-color: var(--primary-red);
   box-shadow: 0 0 0 3px rgba(227, 68, 50, 0.1);
+}
+
+.form-control::placeholder {
+  color: var(--text-tertiary);
+  opacity: 1;
+}
+
+/* Input groups for consistent sizing */
+.input-group .form-control {
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.input-group-text {
+  border: 2px solid var(--border-color);
+  border-right: 0;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  background: var(--accent-bg);
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--spacing-md);
+}
+
+.input-group:focus-within .input-group-text {
+  border-color: var(--primary-red);
+}
+
+.input-group:focus-within .form-control {
+  border-left-color: var(--primary-red);
 }
 
 .form-select {
@@ -400,16 +434,45 @@ a:hover {
 
 .form-error {
   color: var(--priority-high);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   margin-top: var(--spacing-xs);
   display: block;
+  position: absolute;
+  bottom: -1.25rem;
+  left: 0;
+  background: var(--secondary-bg);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .form-success {
   color: var(--success-green);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   margin-top: var(--spacing-xs);
   display: block;
+  position: absolute;
+  bottom: -1.25rem;
+  left: 0;
+  background: var(--secondary-bg);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+}
+
+/* Adjust form group spacing to accommodate error messages */
+.form-group.has-error {
+  margin-bottom: calc(var(--spacing-lg) + 1.5rem);
+}
+
+.form-group.has-success {
+  margin-bottom: calc(var(--spacing-lg) + 1.5rem);
 }
 
 /* ===== ANIMATIONS ===== */

--- a/index.html
+++ b/index.html
@@ -54,15 +54,15 @@
         <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav me-auto">
             <li class="nav-item">
-              <a class="nav-link active" href="index.html">
-                <i class="fas fa-list-check me-1"></i>
-                Tarefas
-              </a>
-            </li>
-            <li class="nav-item">
               <a class="nav-link" href="landing.html">
                 <i class="fas fa-home me-1"></i>
                 Início
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" href="index.html">
+                <i class="fas fa-list-check me-1"></i>
+                Tarefas
               </a>
             </li>
           </ul>


### PR DESCRIPTION
This pull request includes comprehensive form styling improvements and navigation reordering:

**CSS Changes:**
- Changed heading font from "Graphik" to "Inter" for consistency
- Added relative positioning to form groups
- Updated form labels with smaller font size (0.875rem)
- Enhanced form controls with improved padding, border width, and minimum height
- Added placeholder styling and input group components
- Repositioned form error and success messages as absolute positioned tooltips
- Added comprehensive form validation states and accessibility improvements
- Included responsive form adjustments for mobile devices
- Added required field indicators with asterisks

**HTML Changes:**
- Reordered navigation items to show "Início" before "Tarefas"
- Maintained active state on "Tarefas" link

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d8d8d2c0636d4da5b056aec1fa9cd238/spark-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d8d8d2c0636d4da5b056aec1fa9cd238</projectId>-->
<!--<branchName>spark-space</branchName>-->